### PR TITLE
feat: add `new()` and `default()`

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -33,6 +33,18 @@ pub struct RawOneShotMutex {
     lock: AtomicBool,
 }
 
+impl RawOneShotMutex {
+    pub const fn new() -> Self {
+        Self::INIT
+    }
+}
+
+impl Default for RawOneShotMutex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 unsafe impl RawMutex for RawOneShotMutex {
     #[allow(clippy::declare_interior_mutable_const)]
     const INIT: Self = Self {

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -45,6 +45,10 @@ const UPGRADABLE: usize = 1 << 1;
 const EXCLUSIVE: usize = 1;
 
 impl RawOneShotRwLock {
+    pub const fn new() -> Self {
+        Self::INIT
+    }
+
     #[inline]
     fn is_locked_shared(&self) -> bool {
         self.lock.load(Ordering::Relaxed) & !(EXCLUSIVE | UPGRADABLE) != 0
@@ -67,6 +71,12 @@ impl RawOneShotRwLock {
         }
 
         value
+    }
+}
+
+impl Default for RawOneShotRwLock {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
This PR adds:

- `RawOneShotMutex::new()`
- `RawOneShotRwLock::new()`
- `impl Default for RawOneShotMutex`
- `impl Default for RawOneShotRwLock`

These additions allows downstream crates to instantiate `RawOneShotMutex` and `RawOneShotRwLock` without having to depend on `lock_api`.
